### PR TITLE
Initial commit of settings UI

### DIFF
--- a/cmd/katbox.go
+++ b/cmd/katbox.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/kitkat-group/katbox/pkg/ksettings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var userSettingsPath *string
+
+// Release - this struct contains the release information populated when building katbox
+var Release struct {
+	Version string
+	Build   string
+}
+
+var katboxCmd = &cobra.Command{
+	Use:   "katbox",
+	Short: "The \"katbox\" is used to manage articles, artifacts and resources for the KitKat team",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+		cmd.Help()
+		return
+	},
+}
+
+var katboxCmdUser = &cobra.Command{
+	Use:   "user",
+	Short: "The user sub-command allows configuration of user settings",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+		cmd.Help()
+		u, err := ksettings.LoadUserSettings()
+		if err != nil {
+			ksettings.GenerateDefaultSettings(*userSettingsPath)
+			return
+		}
+		u.SettingsUI("Edit existing Settings", ksettings.KsettingsEditors)
+		return
+	},
+}
+
+var logLevel int
+
+func init() {
+	userSettingsPath = katboxCmdUser.Flags().String("settings", "~/.katbox/usrcfg.json", "Path to User Settings")
+	katboxCmd.AddCommand(katboxCmdUser)
+}
+
+// Execute - starts the command parsing process
+func Execute() {
+	if os.Getenv("KATBOX_LOGLEVEL") != "" {
+		i, err := strconv.ParseInt(os.Getenv("KATBOX_LOGLEVEL"), 10, 8)
+		if err != nil {
+			log.Fatalf("Error parsing environment variable [KATBOX_LOGLEVEL")
+		}
+		// We've only parsed to an 8bit integer, however i is still a int64 so needs casting
+		logLevel = int(i)
+	} else {
+		// Default to logging anything Info and below
+		logLevel = int(log.InfoLevel)
+	}
+
+	log.SetLevel(log.Level(logLevel))
+	if err := katboxCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+var katboxVersion = &cobra.Command{
+	Use:   "version",
+	Short: "Version and Release information about the plunder tool",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Plunder Release Information\n")
+		fmt.Printf("Version:  %s\n", Release.Version)
+		fmt.Printf("Build:    %s\n", Release.Build)
+	},
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,15 @@
+package main
+
+import "github.com/kitkat-group/katbox/cmd"
+
+// Version is populated from the Makefile and is tied to the release TAG
+var Version string
+
+// Build is the last GIT commit
+var Build string
+
+func main() {
+	cmd.Release.Version = Version
+	cmd.Release.Build = Build
+	cmd.Execute()
+}

--- a/pkg/kontent/retrieve.go
+++ b/pkg/kontent/retrieve.go
@@ -1,0 +1,6 @@
+package kontent
+
+//Retrieve -
+func Retrieve() error {
+	return nil
+}

--- a/pkg/ksettings/defaults.go
+++ b/pkg/ksettings/defaults.go
@@ -1,0 +1,45 @@
+package ksettings
+
+// The Default settings directory should be {home_dir}/.katbox/
+const ksettingsDir = ".katbox"
+
+// The Default settings directory should be {home_dir}/.katbox/usrcfg.cfg
+const ksettingsUserConfig = "usrcfg.json"
+
+// KsettingsEditors -Editors (arrays are typically mutable, and can't be a const)
+var KsettingsEditors = []string{"vi", "ed", "VSCode", "custom"}
+
+// Paths MacOS
+// - Visual Studio Code
+const ksettingsMacVSCodePath = "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+
+// - Visual Studio Code Download Link (TODO - revisit)
+const ksettingsMacVSCodeURL = "https://go.microsoft.com/fwlink/?LinkID=620882"
+
+// TODO
+// lookupEditor - will lookup the OS/Editor selection and set the default path
+func lookupEditor(editor string) string {
+	// OS lookup
+	// -> Editor lookup
+	// --> find default editor path
+	return "TODO"
+}
+
+// setDefaults - will set a default configuration
+func setDefaults(settingsFilePath string) *User {
+
+	// Populate the default configuration struct
+	u := User{
+		AutoUpdate: false,
+		GitPath:    "~/Documents",
+		OpenURL:    true,
+		Editor:     "vim",
+		ContentURL: "https://raw.githubusercontent.com/kitkat-group/kontent/master/kitkat.json",
+	}
+
+	u.SettingsUI("Set new default settings", KsettingsEditors)
+
+	// Save the updated settings
+
+	return &u
+}

--- a/pkg/ksettings/settings.go
+++ b/pkg/ksettings/settings.go
@@ -1,0 +1,119 @@
+package ksettings
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+// User are the katbox settings that relate to a users configuration
+type User struct {
+
+	// Update Options
+	AutoUpdate bool `json:"autoupdate"`
+
+	// Which editor will be used to open file(s) or directories
+	Editor       string `json:"editor"`
+	CustomEditor string `json:"customEditor,omitEmpty"`
+
+	// TODO - Might be configurable down the line
+	GoPath string `json:"gopath"`
+
+	// Which paths will be used to clone projects
+	GitPath string `json:"gitpath"`
+	// Should URLs be opened by the (default) browser
+	OpenURL bool `json:"openUrl"`
+
+	// ContentURL points to a different kitkat url for source material
+	ContentURL string `json:"customURL"`
+}
+
+// GenerateDefaultSettings - This will create a set of defaults and allow the user to modify them
+func GenerateDefaultSettings(path string) (*User, error) {
+
+	// Start by checking the home directory
+	homeDirectory, err := homedir.Dir()
+	if err != nil {
+		return nil, err
+	}
+
+	if path == "" {
+		path = fmt.Sprintf("%s/%s/%s", homeDirectory, ksettingsDir, ksettingsUserConfig)
+	}
+	// Build new defaults
+	usr := setDefaults(path)
+	usr.SaveUserSettingsToFile(path)
+	return usr, nil
+}
+
+// LoadUserSettings - this will attempt to populate the user settings from the default file
+func LoadUserSettings() (*User, error) {
+	// Start by checking the home directory
+	homeDirectory, err := homedir.Dir()
+	if err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("%s/%s/%s", homeDirectory, ksettingsDir, ksettingsUserConfig)
+
+	// Use the load Settings function
+	usr, err := LoadUserSettingsFromFile(path)
+	if err != nil {
+		log.Infof("%v", err)
+	}
+	return usr, nil
+}
+
+// LoadUserSettingsFromFile - this will attempt to populate the user settings from a local file
+func LoadUserSettingsFromFile(filePath string) (*User, error) {
+	// Check if the file exists, if so attempt to parse it
+	if _, err := os.Stat(filePath); !os.IsExist(err) {
+		// Attempt to read the file into a []byte buffer
+		b, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return nil, err
+		}
+		// Create a struct to parse into
+		var usr User
+		// Unmarshall the rawbytes into a struct
+		err = json.Unmarshal(b, &usr)
+		if err != nil {
+			return nil, err
+		}
+		// Return the user settings
+		return &usr, nil
+	}
+	return nil, fmt.Errorf("File %s doesn't exist", filePath)
+}
+
+// SaveUserSettingsToFile - This will save User settings to a file
+func (u *User) SaveUserSettingsToFile(settingsPath string) error {
+
+	// Marshall the configuration
+	b, err := json.MarshalIndent(u, "", "\t")
+	if err != nil {
+		return err
+	}
+	directoryPath := filepath.Dir(settingsPath)
+	// Create the path if it doesn't exist
+	os.MkdirAll(directoryPath, os.ModePerm)
+	f, err := os.Create(settingsPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	byteCount, err := f.WriteString(string(b))
+	if err != nil {
+		return err
+	}
+	log.Infof("Written %d bytes to file [%s]", byteCount, settingsPath)
+	f.Sync()
+
+	return nil
+}

--- a/pkg/ksettings/ui.go
+++ b/pkg/ksettings/ui.go
@@ -1,0 +1,35 @@
+package ksettings
+
+import (
+	"github.com/rivo/tview"
+)
+
+// SettingsUI - Allows modification of
+func (s *User) SettingsUI(title string, editors []string) {
+	app := tview.NewApplication()
+
+	form := tview.NewForm().
+		AddCheckbox("Update on starting katbox", s.AutoUpdate, nil).
+		AddDropDown("Editor", editors, 0, nil).
+		AddInputField("(optional) Custom editor Path", s.Editor, 30, nil, nil).
+		AddInputField("Git clone path", s.GitPath, 30, nil, nil).
+		AddCheckbox("Open URLs in Browser", s.OpenURL, nil).
+		AddButton("Save Settings", func() { app.Stop() })
+
+	form.SetBorder(true).SetTitle(title).SetTitleAlign(tview.AlignLeft)
+	if err := app.SetRoot(form, true).Run(); err != nil {
+		panic(err)
+	}
+
+	// Retrieve values and update settings
+
+	_, s.Editor = form.GetFormItemByLabel("Editor").(*tview.DropDown).GetCurrentOption()
+	// If a custom editor has been selected then set the value from the custom Editor field
+	if s.Editor == "Custom" {
+		s.CustomEditor = form.GetFormItemByLabel("Editor Path").(*tview.InputField).GetText()
+	}
+
+	// TODO - do a OS/Editor lookup and set the path accordingly
+
+	s.OpenURL = form.GetFormItemByLabel("Open URLs in Browser").(*tview.Checkbox).IsChecked()
+}

--- a/pkg/newsroom/readinglist.go
+++ b/pkg/newsroom/readinglist.go
@@ -1,0 +1,5 @@
+package newsroom
+
+// The newsroom pacakage is used to keep a list of articles that have/haven't been read
+
+//https://godoc.org/github.com/pkg/browser


### PR DESCRIPTION
First commit of the katbox `CLI` tool, currently the basics for end-user configuration currently exist. If a configuration file doesn't exist then a UI with *sensible* defaults will appear.

Additional subcommands will appear to ease the use of the downloaded `kontent`.